### PR TITLE
Fixes redeem address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug on Redeem Address when the page was not redirected
 
 ## [0.3.1] - 2018-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2] - 2018-11-01
 ### Fixed
 - Bug on Redeem Address when the page was not redirected
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "address-locator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/components/Redeem.js
+++ b/react/components/Redeem.js
@@ -40,7 +40,7 @@ class AddressRedeem extends Component {
   updateProfile = async ({ email }) => {
     const { orderFormContext, onOrderFormUpdated } = this.props
 
-    orderFormContext.updateOrderFormProfile({
+    const data = await orderFormContext.updateOrderFormProfile({
       variables: {
         orderFormId: orderFormContext.orderForm.orderFormId,
         fields: { email },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes bug when redeeming address with phone number

#### What problem is this solving?
When submitting the phone number with redeem address, it threw an error and did not redirect the user to the orders page.

#### How should this be manually tested?
1. Visit the [workspace](https://rebuy--delivery.myvtex.com/order)
2. Use the following phone number on "Redeem Address" which already has a profile: `48987654321`
2.a. OR do the full purchase flow to create an order, go back to the landing page with "Redeem Address" and then use the phone number with which you completed the order with
3. It should redirect to the orders page after redeeming the profile

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.