### PR TITLE
Fix/tab changing flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed flicker when changing tabs to "First Order"
 
 ## [0.3.2] - 2018-11-01
 ### Fixed

--- a/react/components/Search.js
+++ b/react/components/Search.js
@@ -26,6 +26,8 @@ class AddressSearch extends Component {
     onOrderFormUpdated: PropTypes.func,
     /* Context used to call address mutation and retrieve the orderForm */
     orderFormContext: contextPropTypes,
+    /* Set to loading mode */
+    loading: PropTypes.bool,
   }
 
   state = {
@@ -200,6 +202,8 @@ class AddressSearch extends Component {
       AlertMessage,
     } = this.state
 
+    const isDisabled = this.props.loading
+
     return (
       <Fragment>
         {AlertMessage &&
@@ -231,13 +235,16 @@ class AddressSearch extends Component {
                     size="large"
                     label={label}
                     onChange={this.handleAddressChanged}
+                    disabled={isDisabled}
                   />
                 )}
               </Adopt>
             </StandaloneSearchBox>
-            <span className="absolute bottom-0 pv4 right-1">
-              <LocationInputIcon onClick={this.handleSetCurrentPosition} />
-            </span>
+            {!isDisabled && (
+              <span className="absolute bottom-0 pv4 right-1">
+                <LocationInputIcon onClick={this.handleSetCurrentPosition} />
+              </span>
+            )}
           </div>
           {address &&
             shouldDisplayNumberInput && (
@@ -287,6 +294,7 @@ class AddressSearch extends Component {
             type="submit"
             disabled={!address || !address.number}
             isLoading={isLoading}
+            disabled={isDisabled}
             block
           >
             <FormattedMessage id="address-locator.address-search-button" />
@@ -311,7 +319,7 @@ export default compose(
         return {
           googleMapKey: googleMapsKey,
           googleMapURL: `https://maps.googleapis.com/maps/api/js?key=${googleMapsKey}&v=3.exp&libraries=places`,
-          loadingElement: <div className="h-100" />,
+          loadingElement: <AddressSearch loading />,
           onOrderFormUpdated: onOrderFormUpdated,
           orderFormContext: orderFormContext,
         }

--- a/react/components/Search.js
+++ b/react/components/Search.js
@@ -204,6 +204,17 @@ class AddressSearch extends Component {
 
     const isDisabled = this.props.loading
 
+    const SearchWrapper = ({children}) =>
+      isDisabled 
+        ? (
+          <div>{children}</div>
+        )
+        : (
+          <StandaloneSearchBox ref={this.searchBox} onPlacesChanged={this.handlePlacesChanged}>
+            {children}
+          </StandaloneSearchBox>
+        )
+
     return (
       <Fragment>
         {AlertMessage &&
@@ -218,7 +229,7 @@ class AddressSearch extends Component {
           )}
         <form className="address-search w-100 pv7 ph6" onSubmit={this.handleFormSubmit}>
           <div className="relative input--icon-right">
-            <StandaloneSearchBox ref={this.searchBox} onPlacesChanged={this.handlePlacesChanged}>
+            <SearchWrapper>
               <Adopt
                 mapper={{
                   placeholder: <FormattedMessage id="address-locator.address-search-placeholder" />,
@@ -228,6 +239,7 @@ class AddressSearch extends Component {
               >
                 {({ placeholder, label, errorMessage }) => (
                   <Input
+                    key="input"
                     type="text"
                     value={formattedAddress}
                     errorMessage={inputError ? errorMessage : ''}
@@ -235,16 +247,13 @@ class AddressSearch extends Component {
                     size="large"
                     label={label}
                     onChange={this.handleAddressChanged}
-                    disabled={isDisabled}
                   />
                 )}
               </Adopt>
-            </StandaloneSearchBox>
-            {!isDisabled && (
-              <span className="absolute bottom-0 pv4 right-1">
-                <LocationInputIcon onClick={this.handleSetCurrentPosition} />
-              </span>
-            )}
+            </SearchWrapper>
+            <span className="absolute bottom-0 pv4 right-1">
+              <LocationInputIcon onClick={this.handleSetCurrentPosition} />
+            </span>
           </div>
           {address &&
             shouldDisplayNumberInput && (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Stops flickering when changing tabs.

It was caused by an empty `div` being rendered while the Google maps was being rendered. This renders the component itself in a disabled mode while loading.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
