### PR TITLE
Add shake to the modal when the user clicks on the overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Clicks outside of the modal now shake the modal in order to call for the user attention
+
 ## [0.4.0] - 2018-11-06
 
 ## [0.3.4] - 2018-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-11-07
+
 ### Added
 
 - Clicks outside of the modal now shake the modal in order to call for the user attention

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "address-locator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/components/AddressModal.js
+++ b/react/components/AddressModal.js
@@ -41,6 +41,38 @@ class AddressModal extends Component {
 
   handleClose = () => this.setState({ isOpen: false })
 
+  componentDidMount() {
+    const overlayElement = document && document.querySelector('.vtex-modal__overlay')
+
+    if(overlayElement){
+      overlayElement.addEventListener('click', this.shakeModal)
+    }
+  }
+
+  componentWillUnmount() {
+    const overlayElement = document && document.querySelector('.vtex-modal__overlay')
+
+    if(overlayElement){
+      overlayElement.removeEventListener('click', this.shakeModal)
+    }
+  }
+
+  shakeModal = e => {
+    const modalElement = document && document.querySelector('.vtex-modal__modal')
+
+    if (modalElement) {
+      if (e.target !== e.currentTarget) {
+        return
+      }
+
+      modalElement.classList.add('animated', 'shake')
+
+      setTimeout(() => {
+        modalElement.classList.remove('shake')
+      }, 1000)
+    }
+  }
+
   /* Function that will be called when updating the orderform */
   handleOrderFormUpdated = async () => await this.props.orderFormContext.refetch()
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Modal calls for the users attention when they click on the overlay, so to give a hint that they have to fill in the address form first.

https://modalattention--delivery.myvtex.com/

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
