### PR TITLE
fix redirect from routes other than home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix redirect when coming from routes other than home.
 
 ## [2.1.5] - 2019-04-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.6] - 2019-04-09
 ### Fixed
 - Fix redirect when coming from routes other than home.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "address-locator",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "builders": {
     "store": "0.x",
     "messages": "1.x",

--- a/react/index.js
+++ b/react/index.js
@@ -38,16 +38,14 @@ class AddressManager extends Component {
     }
   }
 
-  cleanRedirectUrl = (returnURL) => head(returnURL) === '/' ? returnURL : `/${returnURL || ''}`
-
   redirectToReturnURL = () => {
     try {
       const parsedQueryString = queryString.parse(window.location.search)
       const returnURL = parsedQueryString && parsedQueryString.returnUrl  
-      window.location.href = this.cleanRedirectUrl(returnURL)
+      const cleanUrl = head(returnURL) === '/' ? returnURL : `/${returnURL || ''}`
+      window.location.href = cleanUrl
     } catch (e) {
       // Unable to redirect
-      /** TODO: Handle this error better */
     }
   }
 

--- a/react/index.js
+++ b/react/index.js
@@ -41,8 +41,8 @@ class AddressManager extends Component {
   redirectToReturnURL = () => {
     try {
       const parsedQueryString = queryString.parse(window.location.search)
-      const returnURL = parsedQueryString && parsedQueryString.returnUrl  
-      const cleanUrl = head(returnURL) === '/' ? returnURL : `/${returnURL || ''}`
+      const returnURL = parsedQueryString && parsedQueryString.returnUrl  || ''
+      const cleanUrl = head(returnURL) === '/' ? returnURL : `/${returnURL}`
       window.location.href = cleanUrl
     } catch (e) {
       // Unable to redirect

--- a/react/index.js
+++ b/react/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { orderFormConsumer, contextPropTypes } from 'vtex.store-resources/OrderFormContext'
 import AddressPage from './components/AddressPage'
 import hoistNonReactStatics from 'hoist-non-react-statics'
+import { head } from 'ramda'
 import queryString from 'query-string'
 import './global.css'
 
@@ -37,11 +38,13 @@ class AddressManager extends Component {
     }
   }
 
+  cleanRedirectUrl = (returnURL) => head(returnURL) === '/' ? returnURL : `/${returnURL || ''}`
+
   redirectToReturnURL = () => {
     try {
       const parsedQueryString = queryString.parse(window.location.search)
-      const returnURL = parsedQueryString && parsedQueryString.returnUrl
-      window.location.href = `/${returnURL || ''}`
+      const returnURL = parsedQueryString && parsedQueryString.returnUrl  
+      window.location.href = this.cleanRedirectUrl(returnURL)
     } catch (e) {
       // Unable to redirect
       /** TODO: Handle this error better */


### PR DESCRIPTION
http://address--delivery.myvtex.com

Before: if you went to http://address--delivery.myvtex.com/pizza-pepperoni/p, found your address, it redirected you to `https://pizza-pepperoni/p`.

Now: will redirect you to delivery.myvtex.com/pizza-pepperoni/p.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
